### PR TITLE
#35 - 검색 기능을 위해 SearchType 옵션 전달, 테스트 구현

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -39,6 +39,7 @@ public class ArticleController {
 
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("searchTypes", SearchType.values());
         return "articles/index";
     }
 

--- a/src/main/java/com/fastcampus/projectboard/domain/type/SearchType.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/type/SearchType.java
@@ -1,5 +1,17 @@
 package com.fastcampus.projectboard.domain.type;
 
+import lombok.Getter;
+
 public enum SearchType {
-    TITLE, CONTENT, ID, NICKNAME, HASHTAG
+    TITLE("제목"),
+    CONTENT("본문"),
+    ID("유저 ID"),
+    NICKNAME("닉네임"),
+    HASHTAG("해시태그");
+
+    @Getter private final String description;
+
+    SearchType(String description) {
+        this.description = description;
+    }
 }

--- a/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboard/controller/ArticleControllerTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.projectboard.controller;
 
 import com.fastcampus.projectboard.config.SecurityConfig;
+import com.fastcampus.projectboard.domain.type.SearchType;
 import com.fastcampus.projectboard.dto.ArticleDto;
 import com.fastcampus.projectboard.dto.ArticleWithCommentsDto;
 import com.fastcampus.projectboard.dto.UserAccountDto;
@@ -30,7 +31,7 @@ import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@DisplayName("View 컨트롤러 - 게시글")
+@DisplayName("V iew 컨트롤러 - 게시글")
 @Import(SecurityConfig.class)
 @WebMvcTest(ArticleController.class)
 class ArticleControllerTest {
@@ -58,6 +59,30 @@ class ArticleControllerTest {
                 .andExpect(model().attributeExists("articles"))
                 .andExpect(model().attributeExists("paginationBarNumbers"));
         then(articleService).should().searchArticles(eq(null), eq(null), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+    }
+
+    @DisplayName("[view] [GET] 게시글 리스트 (게시판) 페이지 - 검색어와 함께 호출")
+    @Test
+    public void givenSearchKeyword_whenSearchingArticlesView_thenReturnsArticlesView() throws Exception {
+        // given
+        SearchType searchType = SearchType.TITLE;
+        String searchValue = "title";
+        given(articleService.searchArticles(eq(searchType), eq(searchValue), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
+
+        // when & then
+        mvc.perform(get("/articles")
+                        .queryParam("searchType", searchType.name())
+                        .queryParam("searchValue", searchValue)
+
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/index"))
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attributeExists("searchTypes"));
+        then(articleService).should().searchArticles(eq(searchType), eq(searchValue), any(Pageable.class));
         then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
     }
 


### PR DESCRIPTION
게시판 페이지의 검색바에서 검색 종류를 드롭 다운 메뉴로 제공할 때 해당값을 뷰가 알게 하지 않고, 서버로부터 받아서 쓰게 만들기 위해 값을 전달하는 로직을 테스트와 함께 추가

this closes #35 